### PR TITLE
Adds simulation message filtering to analytics message parser.

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/AnalyticsMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/AnalyticsMessageParser.java
@@ -18,6 +18,7 @@ package com.pinterest.secor.parser;
 
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
 import com.pinterest.secor.message.ParsedMessage;
@@ -49,7 +50,8 @@ public class AnalyticsMessageParser extends MessageParser {
     protected static final String defaultType = "untyped";
     protected static final String defaultDate = "1970/01/01/00";
 
-    private JSONObject jsonObject;
+    @VisibleForTesting
+    JSONObject jsonObject;
 
     public AnalyticsMessageParser(SecorConfig config) {
         super(config);

--- a/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
@@ -18,7 +18,6 @@ package com.pinterest.secor.parser;
 
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
-import com.pinterest.secor.message.ParsedMessage;
 
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
@@ -123,8 +122,7 @@ public class AnalyticsMessageParserTest extends TestCase {
 
     @Test
     public void testSimulation() throws Exception {
-        final ParsedMessage m = parser.parse(mSimulation);
-        assertNull(m);
+        assertNull(parser.parse(mSimulation));
     }
 
     private String[] extractPartitions(final Message m) {

--- a/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
@@ -26,6 +26,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
+import com.pinterest.secor.message.ParsedMessage;
 
 @RunWith(PowerMockRunner.class)
 public class AnalyticsMessageParserTest extends TestCase {
@@ -37,6 +38,7 @@ public class AnalyticsMessageParserTest extends TestCase {
     private Message mInvalidPath;
     private Message mRobustInvalidPath;
     private Message mDateWithoutMilliseconds;
+    private Message mSimulation;
 
     @Override
     public void setUp() throws Exception {
@@ -62,6 +64,9 @@ public class AnalyticsMessageParserTest extends TestCase {
 
         byte date_without_milliseconds[] = "{\"timestamp\":\"2015-01-27T18:31:01Z\",\"type\":\"track\",\"event\":\"sometype-v1\"}".getBytes("UTF-8");
         mDateWithoutMilliseconds = new Message("test", 0, 0, date_without_milliseconds);
+
+        byte simulation[] = "{\"timestamp\":\"2015-01-27T18:31:01Z\",\"type\":\"track\",\"event\":\"sometype-v1\",\"properties\":{\"platform\":\"SIMULATION\"}}".getBytes("UTF-8");
+        mSimulation = new Message("test", 0, 0, simulation);
 
     }
 
@@ -99,6 +104,12 @@ public class AnalyticsMessageParserTest extends TestCase {
     public void testDateWithoutMilliseconds() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mDateWithoutMilliseconds);
         assertEquals("2015/01/27/18", result[1]);
+    }
+
+    @Test
+    public void testSimulation() throws Exception {
+        final ParsedMessage m = new AnalyticsMessageParser(mConfig).parse(mSimulation);
+        assertNull(m);
     }
 
 }

--- a/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/AnalyticsMessageParserTest.java
@@ -77,30 +77,35 @@ public class AnalyticsMessageParserTest extends TestCase {
         assertEquals("2014/10/17/01", result[1]);
     }
 
+    @Test
     public void testExtractTypeAndDate2() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mTypeIdentify);
         assertEquals("13/identify", result[0]);
         assertEquals("2014/10/17/13", result[1]);
     }
 
+    @Test
     public void testExtractTypeAndInvalidDate() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mInvalidDate);
         assertEquals("00/availability", result[0]);
         assertEquals("1970/01/01/00", result[1]);
     }
 
+    @Test
     public void testSanitizePath() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mInvalidPath);
         assertEquals("01/taskscheduler-taskpublishedevent-v1-0", result[0]);
         assertEquals("2014/10/17/01", result[1]);
     }
 
+    @Test
     public void testSanitizePathRobust() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mRobustInvalidPath);
         assertEquals("01/searchresults-dir-v1", result[0]);
         assertEquals("2014/10/17/01", result[1]);
     }
 
+    @Test
     public void testDateWithoutMilliseconds() throws Exception {
         String result[] = new AnalyticsMessageParser(mConfig).extractPartitions(mDateWithoutMilliseconds);
         assertEquals("2015/01/27/18", result[1]);

--- a/src/test/java/com/pinterest/secor/parser/LogstashMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/LogstashMessageParserTest.java
@@ -78,29 +78,34 @@ public class LogstashMessageParserTest extends TestCase {
         assertEquals("2014/10/17/01", result[1]);
     }
 
+    @Test
     public void testExtractTypeAndInvalidDate() throws Exception {
         String result[] = new LogstashMessageParser(mConfig).extractPartitions(mFormat2);
         assertEquals("restaurant-service-v1", result[0]);
         assertEquals("1970/01/01/00", result[1]);
     }
 
+    @Test
     public void testExtractNoTypeAndDate() throws Exception {
         String result[] = new LogstashMessageParser(mConfig).extractPartitions(mFormat3);
         assertEquals("untyped", result[0]);
         assertEquals("2014/10/17/01", result[1]);
     }
 
+    @Test
     public void testExtractNoTypeAndInvalidDate() throws Exception {
         String result[] = new LogstashMessageParser(mConfig).extractPartitions(mFormat4);
         assertEquals("untyped", result[0]);
         assertEquals("1970/01/01/00", result[1]);
     }
 
+    @Test
     public void testSanitizePath() throws Exception {
         String result[] = new LogstashMessageParser(mConfig).extractPartitions(mInvalidPath);
         assertEquals("taskscheduler-taskpublishedevent-v1-0", result[0]);
     }
 
+    @Test
     public void testSanitizePathRobust() throws Exception {
         byte invalid_path2[] = "{\"@timestamp\":\"33333333333\",\"type\":\"search:*results-'|dir-v1\",\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\"}".getBytes("UTF-8");
         Message mInvalidPath2 = new Message("test", 0, 0, invalid_path2);
@@ -108,6 +113,7 @@ public class LogstashMessageParserTest extends TestCase {
         assertEquals("searchresults-dir-v1", result[0]);
     }
 
+    @Test
     public void testDateWithoutMilliseconds() throws Exception {
         String result[] = new LogstashMessageParser(mConfig).extractPartitions(mDateWithoutMilliseconds);
         assertEquals("2015/01/27/18", result[1]);


### PR DESCRIPTION
https://opentable.atlassian.net/browse/OTPL-991
Cf. https://github.com/opentable/docker-secor/pull/2

This is a little ghetto.  I do think I see a path for us to actually use upstream Secor and not have to continue to maintain this fork.  We'd create a wrapper project that uses Secor upstream and defines our custom parser.  There might be some funny business with respect to the config, but I think we could work it out.  This doesn't do that.  This is only to filter out simulated analytics events (ones with the `platform` set to `"SIMULATION"` under the `properties` map) from the A/B event generator (https://github.com/opentable/service-abtest-event-generator/).  We want to throw lots of simulated events through, but don't want to archive them in S3 or risk polluting any downstream analysis performed on the archived events.